### PR TITLE
Add time to deploy changes to your site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Your own unique website can be your identity on the Internet! You can use it to 
 1. Fork this repository to your user account.
 2. Rename it to `<yourusername>.github.io`
 3. Edit `index.html` and put stuff there.
-4. (Optional) [Point your domain to Github](https://help.github.com/articles/using-a-custom-domain-with-github-pages/).
+4. Wait a minute for GitHub to publish your site. Then, check <yourusername>.github.io.
+5. (Optional) [Point your domain to Github](https://help.github.com/articles/using-a-custom-domain-with-github-pages/).
 
 Per [CC0](http://creativecommons.org/publicdomain/zero/1.0/), to the extent possible under law, [the contributors](https://github.com/indieweb/blank-gh-site/graphs/contributors) have waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
This PR adds a sentence that makes the reader aware it might take a minute for their site to be deployed on GitHub Pages. This notice has been added to reduce the potential frustration one might face if they have just made a change to their site but do not immediately see that change on the deployed version of their site.